### PR TITLE
Fix bug when adding empty components

### DIFF
--- a/src/vhtml.js
+++ b/src/vhtml.js
@@ -13,7 +13,7 @@ export default function h(name, attrs) {
 
 	// Sortof component support!
 	if (typeof name==='function') {
-		attrs.children = stack.reverse();
+		if (attrs) attrs.children = stack.reverse();
 		return name(attrs);
 		// return name(attrs, stack.reverse());
 	}


### PR DESCRIPTION
I found a small bug when creating an empty component (with no children) like this:

``` js
/** @jsx vhtml */

let items = ['one', 'two'];

const Item = ({ item, index, children }) => (
  <li id={index}>
    <h4>{item}</h4>
    {children}
  </li>
);

document.body.innerHTML = (
	 <div class="foo">
    <h1>Hi!</h1>
    <ul>
      { items.map( (item, index) => (
        <Item>
          This is item {item}!
        </Item>
      )) }
    </ul>
  </div>
);
```

This small change should fix it. Hope it helps!