### PR TITLE
Support empty (void) tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,8 @@
     "rollup-plugin-babel": "^2.4.0",
     "rollup-plugin-es3": "^1.0.3",
     "uglify-js": "^2.6.2"
+  },
+  "dependencies": {
+    "empty-tags": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -69,8 +69,5 @@
     "rollup-plugin-babel": "^2.4.0",
     "rollup-plugin-es3": "^1.0.3",
     "uglify-js": "^2.6.2"
-  },
-  "dependencies": {
-    "empty-tags": "^1.0.0"
   }
 }

--- a/src/empty-tags.js
+++ b/src/empty-tags.js
@@ -1,0 +1,18 @@
+export default [
+	'area',
+	'base',
+	'br',
+	'col',
+	'command',
+	'embed',
+	'hr',
+	'img',
+	'input',
+	'keygen',
+	'link',
+	'meta',
+	'param',
+	'source',
+	'track',
+	'wbr'
+];

--- a/src/vhtml.js
+++ b/src/vhtml.js
@@ -1,4 +1,4 @@
-import emptyTags from 'empty-tags';
+import emptyTags from './empty-tags';
 
 // escape an attribute
 let esc = str => String(str).replace(/[&<>"']/g, s=>`&${map[s]};`);

--- a/src/vhtml.js
+++ b/src/vhtml.js
@@ -1,3 +1,5 @@
+import emptyTags from 'empty-tags';
+
 // escape an attribute
 let esc = str => String(str).replace(/[&<>"']/g, s=>`&${map[s]};`);
 let map = {'&':'amp','<':'lt','>':'gt','"':'quot',"'":'apos'};
@@ -24,20 +26,26 @@ export default function h(name, attrs) {
 			s += ` ${esc(i)}="${esc(attrs[i])}"`;
 		}
 	}
-	s += '>';
 
-	while (stack.length) {
-		let child = stack.pop();
-		if (child) {
-			if (child.pop) {
-				for (let i=child.length; i--; ) stack.push(child[i]);
-			}
-			else {
-				s += sanitized[child]===true ? child : esc(child);
+	if (emptyTags.indexOf(name) === -1) {
+		s += '>';
+
+		while (stack.length) {
+			let child = stack.pop();
+			if (child) {
+				if (child.pop) {
+					for (let i=child.length; i--; ) stack.push(child[i]);
+				}
+				else {
+					s += sanitized[child]===true ? child : esc(child);
+				}
 			}
 		}
+
+		sanitized[s += `</${name}>`] = true;
+	} else {
+		sanitized[s += '>'] = true;
 	}
 
-	sanitized[s += `</${name}>`] = true;
 	return s;
 }

--- a/src/vhtml.js
+++ b/src/vhtml.js
@@ -42,10 +42,11 @@ export default function h(name, attrs) {
 			}
 		}
 
-		sanitized[s += `</${name}>`] = true;
+		s += `</${name}>`;
 	} else {
-		sanitized[s += '>'] = true;
+		s += '>';
 	}
 
+	sanitized[s] = true;
 	return s;
 }

--- a/test/vhtml.js
+++ b/test/vhtml.js
@@ -77,4 +77,29 @@ describe('vhtml', () => {
 			`<div class="foo"><h1>Hi!</h1><ul><li id="0"><h4>one</h4>This is item one!</li><li id="1"><h4>two</h4>This is item two!</li></ul></div>`
 		);
 	});
+
+	it('should understand empty elements', () => {
+		expect(
+			<div>
+				<area />
+				<base />
+				<br />
+				<col />
+				<command />
+				<embed />
+				<hr />
+				<img />
+				<input />
+				<keygen />
+				<link />
+				<meta />
+				<param />
+				<source />
+				<track />
+				<wbr />
+			</div>
+		).to.equal(
+			`<div><area><base><br><col><command><embed><hr><img><input><keygen><link><meta><param><source><track><wbr></div>`
+		);
+	});
 });

--- a/test/vhtml.js
+++ b/test/vhtml.js
@@ -97,9 +97,13 @@ describe('vhtml', () => {
 				<source />
 				<track />
 				<wbr />
+				{/* Not void elements */}
+				<div />
+				<span />
+				<p />
 			</div>
 		).to.equal(
-			`<div><area><base><br><col><command><embed><hr><img><input><keygen><link><meta><param><source><track><wbr></div>`
+			`<div><area><base><br><col><command><embed><hr><img><input><keygen><link><meta><param><source><track><wbr><div></div><span></span><p></p></div>`
 		);
 	});
 });

--- a/test/vhtml.js
+++ b/test/vhtml.js
@@ -78,7 +78,7 @@ describe('vhtml', () => {
 		);
 	});
 
-	it('should understand empty elements', () => {
+	it('should support empty (void) tags', () => {
 		expect(
 			<div>
 				<area />


### PR DESCRIPTION
@developit I'm actually not sure how it worked before without this feature, but it was producing things like `<input type="text"></input>` which is kind of wrong markup (though browsers understand it..).

In this PR I load list of empty tags from `empty-tags` module which I crated long time ago for OpenJSX. Though, if you think that it makes sense inline them directly into project (separate file but in the repo) then I'll do that.

I intentionally don't do any warning here when child elements are added to elements empty elements, but if that makes sense we can probably do that with a `process.ENV === 'development'` guard.

