### PR TITLE
Support className attribute

### DIFF
--- a/src/vhtml.js
+++ b/src/vhtml.js
@@ -23,7 +23,7 @@ export default function h(name, attrs) {
 	let s = `<${name}`;
 	if (attrs) for (let i in attrs) {
 		if (attrs[i]!==false && attrs[i]!=null) {
-			s += ` ${esc(i)}="${esc(attrs[i])}"`;
+			s += ` ${i === 'className' ? 'class' : esc(i)}="${esc(attrs[i])}"`;
 		}
 	}
 

--- a/test/vhtml.js
+++ b/test/vhtml.js
@@ -157,4 +157,12 @@ describe('vhtml', () => {
 			`<div><area><base><br><col><command><embed><hr><img><input><keygen><link><meta><param><source><track><wbr><div></div><span></span><p></p></div>`
 		);
 	});
+
+	it('should handle className as class', () => {
+		expect(
+			<div className="my-class" />
+		).to.equal(
+			'<div class="my-class"></div>'
+		);
+	});
 });


### PR DESCRIPTION
A lot of JSX uses `className` as an attribute for `class`, since `class` is a reserved keyword in ES6. This adds support. Adds 23 bytes (548 bytes to 571 bytes).