### PR TITLE
Create element instances, then resolve to strings

### DIFF
--- a/src/vhtml.js
+++ b/src/vhtml.js
@@ -13,7 +13,9 @@ let sanitized = {};
 function Element(name, attrs, stack) {
 	this.type = name;
 	this.props = attrs || {};
-	this.toString = _h.bind(this, name, stack);
+	this.toString = function () {
+		return _h(this.type, this.props, stack);
+	};
 }
 
 /** Hyperscript reviver that constructs a sanitized HTML string. */
@@ -26,9 +28,7 @@ export default function h(name, attrs) {
 	return new Element(name, attrs, stack);
 }
 
-function _h(name, stack) {
-	let attrs = this.props;
-
+function _h(name, attrs, stack) {
 	// Sortof component support!
 	if (typeof name==='function') {
 		attrs.children = stack.reverse();

--- a/src/vhtml.js
+++ b/src/vhtml.js
@@ -10,6 +10,12 @@ let DOMAttributeNames = {
 
 let sanitized = {};
 
+function Element(name, attrs, stack) {
+	this.type = typeof name === 'function' ? name.name : name;
+	this.props = attrs || {};
+	this.toString = _h.bind(this, name, stack);
+}
+
 /** Hyperscript reviver that constructs a sanitized HTML string. */
 export default function h(name, attrs) {
 	let stack=[];
@@ -17,11 +23,16 @@ export default function h(name, attrs) {
 		stack.push(arguments[i]);
 	}
 
+	return new Element(name, attrs, stack);
+}
+
+function _h(name, stack) {
+	let attrs = this.props;
+
 	// Sortof component support!
 	if (typeof name==='function') {
-		(attrs || (attrs = {})).children = stack.reverse();
-		return name(attrs);
-		// return name(attrs, stack.reverse());
+		attrs.children = stack.reverse();
+		return String(name(attrs));
 	}
 
 	let s = `<${name}`;
@@ -41,7 +52,8 @@ export default function h(name, attrs) {
 					for (let i=child.length; i--; ) stack.push(child[i]);
 				}
 				else {
-					s += sanitized[child]===true ? child : esc(child);
+					let resolved = String(child);
+					s += sanitized[resolved]===true ? resolved : esc(resolved);
 				}
 			}
 		}

--- a/src/vhtml.js
+++ b/src/vhtml.js
@@ -11,7 +11,7 @@ let DOMAttributeNames = {
 let sanitized = {};
 
 function Element(name, attrs, stack) {
-	this.type = typeof name === 'function' ? name.name : name;
+	this.type = name;
 	this.props = attrs || {};
 	this.toString = _h.bind(this, name, stack);
 }

--- a/test/vhtml.js
+++ b/test/vhtml.js
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 describe('vhtml', () => {
 	it('should stringify html', () => {
 		let items = ['one', 'two', 'three'];
-		expect(
+		expect(String(
 			<div class="foo">
 				<h1>Hi!</h1>
 				<p>Here is a list of {items.length} items:</p>
@@ -16,38 +16,38 @@ describe('vhtml', () => {
 					)) }
 				</ul>
 			</div>
-		).to.equal(
+		)).to.equal(
 			`<div class="foo"><h1>Hi!</h1><p>Here is a list of 3 items:</p><ul><li>one</li><li>two</li><li>three</li></ul></div>`
 		);
 	});
 
 	it('should sanitize children', () => {
-		expect(
+		expect(String(
 			<div>
 				{ `<strong>blocked</strong>` }
 				<em>allowed</em>
 			</div>
-		).to.equal(
+		)).to.equal(
 			`<div>&lt;strong&gt;blocked&lt;/strong&gt;<em>allowed</em></div>`
 		);
 	});
 
 	it('should sanitize attributes', () => {
-		expect(
+		expect(String(
 			<div onclick={`&<>"'`} />
-		).to.equal(
+		)).to.equal(
 			`<div onclick="&amp;&lt;&gt;&quot;&apos;"></div>`
 		);
 	});
 
 	it('should flatten children', () => {
-		expect(
+		expect(String(
 			<div>
 				{[['a','b']]}
 				<c>d</c>
 				{['e',['f'],[['g']]]}
 			</div>
-		).to.equal(
+		)).to.equal(
 			`<div>ab<c>d</c>efg</div>`
 		);
 	});
@@ -62,7 +62,7 @@ describe('vhtml', () => {
 			</li>
 		);
 
-		expect(
+		expect(String(
 			<div class="foo">
 				<h1>Hi!</h1>
 				<ul>
@@ -73,7 +73,7 @@ describe('vhtml', () => {
 					)) }
 				</ul>
 			</div>
-		).to.equal(
+		)).to.equal(
 			`<div class="foo"><h1>Hi!</h1><ul><li id="0"><h4>one</h4>This is item one!</li><li id="1"><h4>two</h4>This is item two!</li></ul></div>`
 		);
 	});
@@ -87,7 +87,7 @@ describe('vhtml', () => {
 	    </li>
 	  );
 
-	  expect(
+	  expect(String(
 	    <div class="foo">
 	      <h1>Hi!</h1>
 	      <ul>
@@ -98,7 +98,7 @@ describe('vhtml', () => {
 	        )) }
 	      </ul>
 	    </div>
-	  ).to.equal(
+	  )).to.equal(
 	    `<div class="foo"><h1>Hi!</h1><ul><li><h4></h4></li><li><h4></h4></li></ul></div>`
 	  );
 	});
@@ -113,7 +113,7 @@ describe('vhtml', () => {
 	    </li>
 	  );
 
-	  expect(
+	  expect(String(
 	    <div class="foo">
 	      <h1>Hi!</h1>
 	      <ul>
@@ -124,13 +124,13 @@ describe('vhtml', () => {
 	        )) }
 	      </ul>
 	    </div>
-	  ).to.equal(
+	  )).to.equal(
 	    `<div class="foo"><h1>Hi!</h1><ul><li><h4></h4>This is item one!</li><li><h4></h4>This is item two!</li></ul></div>`
 	  );
 	});
 
 	it('should support empty (void) tags', () => {
-		expect(
+		expect(String(
 			<div>
 				<area />
 				<base />
@@ -153,15 +153,15 @@ describe('vhtml', () => {
 				<span />
 				<p />
 			</div>
-		).to.equal(
+		)).to.equal(
 			`<div><area><base><br><col><command><embed><hr><img><input><keygen><link><meta><param><source><track><wbr><div></div><span></span><p></p></div>`
 		);
 	});
 
 	it('should handle special prop names', () => {
-		expect(
+		expect(String(
 			<div className="my-class" htmlFor="id" />
-		).to.equal(
+		)).to.equal(
 			'<div class="my-class" for="id"></div>'
 		);
 	});


### PR DESCRIPTION
__Updated with new approach__

This PR changes the behavior of `h()` from immediately executed functions, to a function that first creates element instances, and then later resolves them to a string. This means that JSX is now executed in a top-down order, instead of executing the most deeply nested function first. This also makes `props.children` an array of elements (instead of resolved strings), that can be manipulated similar to React.Children.

Consider this JSX:

```js
<Article>
    <Heading>
    <Body>
        <Image />
    </Body>
</Article>
```

The current execution order is: `Image(), Heading(), Body(), Article()`. This PR switches that to the "expected" `Article(), Heading(), Body(), Image()`.

An example using new `props.children`:

```js
const Item = props => (
  <li>
    <h4>{props.title}</h4>
  </li>
);

const List = props => (
  <ul>{props.children.map(child => { child.props.title = 'Overridden'; return child; }  }</ul>
);

console.log(
  <List>
    <Item title="First" />
    <Item title="Second" />
  </List>
);
```

Output:

```html
<ul>
  <li>Overridden</li>
  <li>Overridden</li>
</ul>
```

__Semi-breaking Changes__

- The public JSX/vhtml API must be explicitly cast to a string. The element object uses `toString` to output the HTML. `innerHTML = <Article>` still works because innerHTML casts to a string.

- Size: + 56 bytes, from 580 bytes to 636.

I believe this makes vhtml more consistent with other JSX implementations like React/Preact. It's certainly much more powerful, at the cost of 56 bytes.