### PR TITLE
Support htmlFor as well

### DIFF
--- a/src/vhtml.js
+++ b/src/vhtml.js
@@ -3,6 +3,10 @@ import emptyTags from './empty-tags';
 // escape an attribute
 let esc = str => String(str).replace(/[&<>"']/g, s=>`&${map[s]};`);
 let map = {'&':'amp','<':'lt','>':'gt','"':'quot',"'":'apos'};
+let DOMAttributeNames = {
+	className: 'class',
+	htmlFor: 'for'
+};
 
 let sanitized = {};
 
@@ -23,7 +27,7 @@ export default function h(name, attrs) {
 	let s = `<${name}`;
 	if (attrs) for (let i in attrs) {
 		if (attrs[i]!==false && attrs[i]!=null) {
-			s += ` ${i === 'className' ? 'class' : esc(i)}="${esc(attrs[i])}"`;
+			s += ` ${DOMAttributeNames[i] ? DOMAttributeNames[i] : esc(i)}="${esc(attrs[i])}"`;
 		}
 	}
 

--- a/test/vhtml.js
+++ b/test/vhtml.js
@@ -158,11 +158,11 @@ describe('vhtml', () => {
 		);
 	});
 
-	it('should handle className as class', () => {
+	it('should handle special prop names', () => {
 		expect(
-			<div className="my-class" />
+			<div className="my-class" htmlFor="id" />
 		).to.equal(
-			'<div class="my-class"></div>'
+			'<div class="my-class" for="id"></div>'
 		);
 	});
 });


### PR DESCRIPTION
Pulled from https://github.com/facebook/react/blob/b1768b5/src/renderers/dom/shared/HTMLDOMPropertyConfig.js#L208-L213

I don't think `acceptCharset` and `httpEquiv` are relevant, since they were meant for attributes being assigned programmatically (vs vhtml's string concatenation). 

Adds 15 bytes. 565 bytes to 580 bytes.