### PR TITLE
es3 plugin no longer needed, fixes sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "pretty-bytes-cli": "^1.0.0",
     "rollup": "^0.36.3",
     "rollup-plugin-babel": "^2.4.0",
-    "rollup-plugin-es3": "^1.0.3",
     "uglify-js": "^2.6.2"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,6 @@
 import path from 'path';
 import fs from 'fs';
 import babel from 'rollup-plugin-babel';
-import es3 from 'rollup-plugin-es3';
 
 let pkg = JSON.parse(fs.readFileSync('./package.json'));
 
@@ -20,7 +19,6 @@ export default {
 				['es2015', { loose:true, modules:false }]
 			].concat(pkg.babel.presets.slice(1)),
 			plugins: pkg.babel.plugins
-		}),
-		es3()
+		})
 	]
 };


### PR DESCRIPTION
What it says on the tin. es3 removes `defineProperty` and `freeze`, but those are no longer added by Rollup/Babel. It was also wiping sourcemaps, so this fixes that too.