### PR TITLE
Address vhtml#11: Add ability to directly set innerHTML of a component using the `dangerouslySetInnerHTML` attribute.

### DIFF
--- a/src/vhtml.js
+++ b/src/vhtml.js
@@ -13,7 +13,7 @@ let sanitized = {};
 
 /** Hyperscript reviver that constructs a sanitized HTML string. */
 export default function h(name, attrs) {
-	let stack=[];
+	let stack=[], s = `<${name}`;
 	for (let i=arguments.length; i-- > 2; ) {
 		stack.push(arguments[i]);
 	}
@@ -25,7 +25,6 @@ export default function h(name, attrs) {
 		// return name(attrs, stack.reverse());
 	}
 
-	let s = `<${name}`;
 	if (attrs) for (let i in attrs) {
 		if (attrs[i]!==false && attrs[i]!=null && i !== setInnerHTMLAttr) {
 			s += ` ${DOMAttributeNames[i] ? DOMAttributeNames[i] : esc(i)}="${esc(attrs[i])}"`;

--- a/src/vhtml.js
+++ b/src/vhtml.js
@@ -3,6 +3,7 @@ import emptyTags from './empty-tags';
 // escape an attribute
 let esc = str => String(str).replace(/[&<>"']/g, s=>`&${map[s]};`);
 let map = {'&':'amp','<':'lt','>':'gt','"':'quot',"'":'apos'};
+let setInnerHTMLAttr = 'dangerouslySetInnerHTML';
 let DOMAttributeNames = {
 	className: 'class',
 	htmlFor: 'for'
@@ -26,7 +27,7 @@ export default function h(name, attrs) {
 
 	let s = `<${name}`;
 	if (attrs) for (let i in attrs) {
-		if (attrs[i]!==false && attrs[i]!=null) {
+		if (attrs[i]!==false && attrs[i]!=null && i !== setInnerHTMLAttr) {
 			s += ` ${DOMAttributeNames[i] ? DOMAttributeNames[i] : esc(i)}="${esc(attrs[i])}"`;
 		}
 	}
@@ -34,7 +35,10 @@ export default function h(name, attrs) {
 	if (emptyTags.indexOf(name) === -1) {
 		s += '>';
 
-		while (stack.length) {
+		if (attrs && attrs[setInnerHTMLAttr] && attrs[setInnerHTMLAttr].__html) {
+			s += attrs[setInnerHTMLAttr].__html;
+		}
+		else while (stack.length) {
 			let child = stack.pop();
 			if (child) {
 				if (child.pop) {

--- a/src/vhtml.js
+++ b/src/vhtml.js
@@ -14,18 +14,19 @@ let sanitized = {};
 /** Hyperscript reviver that constructs a sanitized HTML string. */
 export default function h(name, attrs) {
 	let stack=[], s = `<${name}`;
+	attrs = attrs || {};
 	for (let i=arguments.length; i-- > 2; ) {
 		stack.push(arguments[i]);
 	}
 
 	// Sortof component support!
 	if (typeof name==='function') {
-		(attrs || (attrs = {})).children = stack.reverse();
+		attrs.children = stack.reverse();
 		return name(attrs);
 		// return name(attrs, stack.reverse());
 	}
 
-	if (attrs) for (let i in attrs) {
+	for (let i in attrs) {
 		if (attrs[i]!==false && attrs[i]!=null && i !== setInnerHTMLAttr) {
 			s += ` ${DOMAttributeNames[i] ? DOMAttributeNames[i] : esc(i)}="${esc(attrs[i])}"`;
 		}
@@ -33,7 +34,7 @@ export default function h(name, attrs) {
 	s += '>';
 
 	if (emptyTags.indexOf(name) === -1) {
-		if (attrs && attrs[setInnerHTMLAttr]) {
+		if (attrs[setInnerHTMLAttr]) {
 			s += attrs[setInnerHTMLAttr].__html;
 		}
 		else while (stack.length) {

--- a/src/vhtml.js
+++ b/src/vhtml.js
@@ -31,10 +31,9 @@ export default function h(name, attrs) {
 			s += ` ${DOMAttributeNames[i] ? DOMAttributeNames[i] : esc(i)}="${esc(attrs[i])}"`;
 		}
 	}
+	s += '>';
 
 	if (emptyTags.indexOf(name) === -1) {
-		s += '>';
-
 		if (attrs && attrs[setInnerHTMLAttr]) {
 			s += attrs[setInnerHTMLAttr].__html;
 		}
@@ -51,8 +50,6 @@ export default function h(name, attrs) {
 		}
 
 		s += `</${name}>`;
-	} else {
-		s += '>';
 	}
 
 	sanitized[s] = true;

--- a/src/vhtml.js
+++ b/src/vhtml.js
@@ -35,7 +35,7 @@ export default function h(name, attrs) {
 	if (emptyTags.indexOf(name) === -1) {
 		s += '>';
 
-		if (attrs && attrs[setInnerHTMLAttr] && attrs[setInnerHTMLAttr].__html) {
+		if (attrs && attrs[setInnerHTMLAttr]) {
 			s += attrs[setInnerHTMLAttr].__html;
 		}
 		else while (stack.length) {

--- a/test/vhtml.js
+++ b/test/vhtml.js
@@ -40,6 +40,14 @@ describe('vhtml', () => {
 		);
 	});
 
+	it('should not sanitize the "dangerouslySetInnerHTML" attribute, and directly set its `__html` property as innerHTML', () => {
+		expect(
+			<div dangerouslySetInnerHTML={{ __html: "<span>Injected HTML</span>" }} />
+		).to.equal(
+			`<div><span>Injected HTML</span></div>`
+		);
+	});
+
 	it('should flatten children', () => {
 		expect(
 			<div>


### PR DESCRIPTION
Should take care of #11.

~~New Size: `630B`~~.
~~New Size: `624B`~~.
New Size: `615B`.

~~`50B` is kinda significant :cry: but I consider this a useful feature.~~

This was initially a `50B` increase in size but is now worked down to `35B` increase in size.