### PR TITLE
Support fragments via h(null, null, ...args)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
   - 4
+  - "lts/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
-node_js:
-  - 8
-  - "lts/*"
+node_js: node
+cache: npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - 4
+  - 8
   - "lts/*"

--- a/src/vhtml.js
+++ b/src/vhtml.js
@@ -31,7 +31,7 @@ export default function h(name, attrs) {
 		}
 	}
 
-	if ((emptyTags.indexOf(name) === -1)) {
+	if (emptyTags.indexOf(name) === -1) {
 		s += name ? '>' : '';
 
 		while (stack.length) {

--- a/src/vhtml.js
+++ b/src/vhtml.js
@@ -24,15 +24,15 @@ export default function h(name, attrs) {
 		// return name(attrs, stack.reverse());
 	}
 
-	let s = `<${name}`;
-	if (attrs) for (let i in attrs) {
+	let s = name ? `<${name}` : '';
+	if (name && attrs) for (let i in attrs) {
 		if (attrs[i]!==false && attrs[i]!=null) {
 			s += ` ${DOMAttributeNames[i] ? DOMAttributeNames[i] : esc(i)}="${esc(attrs[i])}"`;
 		}
 	}
 
-	if (emptyTags.indexOf(name) === -1) {
-		s += '>';
+	if ((emptyTags.indexOf(name) === -1)) {
+		s += name ? '>' : '';
 
 		while (stack.length) {
 			let child = stack.pop();
@@ -46,9 +46,9 @@ export default function h(name, attrs) {
 			}
 		}
 
-		s += `</${name}>`;
+		s += name ? `</${name}>` : '';
 	} else {
-		s += '>';
+		s += name ? '>' : '';
 	}
 
 	sanitized[s] = true;

--- a/src/vhtml.js
+++ b/src/vhtml.js
@@ -13,7 +13,7 @@ let sanitized = {};
 
 /** Hyperscript reviver that constructs a sanitized HTML string. */
 export default function h(name, attrs) {
-	let stack=[], s = `<${name}`;
+	let stack=[], s = name ? `<${name}` : '';
 	attrs = attrs || {};
 	for (let i=arguments.length; i-- > 2; ) {
 		stack.push(arguments[i]);
@@ -26,7 +26,6 @@ export default function h(name, attrs) {
 		// return name(attrs, stack.reverse());
 	}
 
-	let s = name ? `<${name}` : '';
 	if (name && attrs) for (let i in attrs) {
 		if (attrs[i]!==false && attrs[i]!=null && i !== setInnerHTMLAttr) {
 			s += ` ${DOMAttributeNames[i] ? DOMAttributeNames[i] : esc(i)}="${esc(attrs[i])}"`;

--- a/src/vhtml.js
+++ b/src/vhtml.js
@@ -13,7 +13,7 @@ let sanitized = {};
 
 /** Hyperscript reviver that constructs a sanitized HTML string. */
 export default function h(name, attrs) {
-	let stack=[], s = name ? `<${name}` : '';
+	let stack=[], s = '';
 	attrs = attrs || {};
 	for (let i=arguments.length; i-- > 2; ) {
 		stack.push(arguments[i]);
@@ -26,12 +26,15 @@ export default function h(name, attrs) {
 		// return name(attrs, stack.reverse());
 	}
 
-	if (name && attrs) for (let i in attrs) {
-		if (attrs[i]!==false && attrs[i]!=null && i !== setInnerHTMLAttr) {
-			s += ` ${DOMAttributeNames[i] ? DOMAttributeNames[i] : esc(i)}="${esc(attrs[i])}"`;
+	if (name) {
+		s += '<' + name;
+		if (attrs) for (let i in attrs) {
+			if (attrs[i]!==false && attrs[i]!=null && i !== setInnerHTMLAttr) {
+				s += ` ${DOMAttributeNames[i] ? DOMAttributeNames[i] : esc(i)}="${esc(attrs[i])}"`;
+			}
 		}
+		s += '>';
 	}
-	s += name ? '>' : '';
 
 	if (emptyTags.indexOf(name) === -1) {
 		if (attrs[setInnerHTMLAttr]) {

--- a/test/vhtml.js
+++ b/test/vhtml.js
@@ -165,4 +165,21 @@ describe('vhtml', () => {
 			'<div class="my-class" for="id"></div>'
 		);
 	});
+
+	it('should support string fragments', () => {
+		expect(
+			h(null, null, "foo", "bar", "baz")
+		).to.equal(
+			'foobarbaz'
+		);
+	});
+
+	it('should support element fragments', () => {
+		expect(
+			h(null, null, <p>foo</p>, <em>bar</em>, <div class="qqqqqq">baz</div>)
+		).to.equal(
+			'<p>foo</p><em>bar</em><div class="qqqqqq">baz</div>'
+		);
+	});
+
 });


### PR DESCRIPTION
How do you feel about supporting "fragments" via the form `h(null, null, "foo", "bar", "baz")` => `foobarbaz`? (Without this PR, the return value is `<null>foobarbaz</null>`.)

This would make it possible to use JSX's fragment short form (`<>...</>`) via TypeScript. It will only become *easy* to do once https://github.com/Microsoft/TypeScript/issues/20469 is fixed, but with this PR, it at least becomes *possible* with workaround wrapper code such as:

```ts
import h = require("vhtml");

export const React = {
  createElement: h,
  Fragment: ({ children }: { children: string[] }) => h(null, null, ...children),
};
```