### PR TITLE
Add support for dangerouslySetInnerHTML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
-  - 4
+  - 8
+  - "lts/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
-node_js:
-  - 8
-  - "lts/*"
+node_js: node
+cache: npm

--- a/src/vhtml.js
+++ b/src/vhtml.js
@@ -24,26 +24,36 @@ export default function h(name, attrs) {
 		// return name(attrs, stack.reverse());
 	}
 
+	let innerHTML = null;
+
 	let s = `<${name}`;
 	if (attrs) for (let i in attrs) {
 		if (attrs[i]!==false && attrs[i]!=null) {
-			s += ` ${DOMAttributeNames[i] ? DOMAttributeNames[i] : esc(i)}="${esc(attrs[i])}"`;
+			if (i.toLowerCase() === 'dangerouslysetinnerhtml') {
+				innerHTML = attrs[i].__html ? attrs[i].__html : '';
+			} else {
+				s += ` ${DOMAttributeNames[i] ? DOMAttributeNames[i] : esc(i)}="${esc(attrs[i])}"`;
+			}
 		}
 	}
 
 	if (emptyTags.indexOf(name) === -1) {
 		s += '>';
 
-		while (stack.length) {
-			let child = stack.pop();
-			if (child) {
-				if (child.pop) {
-					for (let i=child.length; i--; ) stack.push(child[i]);
-				}
-				else {
-					s += sanitized[child]===true ? child : esc(child);
+		if (innerHTML === null) {
+			while (stack.length) {
+				let child = stack.pop();
+				if (child) {
+					if (child.pop) {
+						for (let i=child.length; i--; ) stack.push(child[i]);
+					}
+					else {
+						s += sanitized[child]===true ? child : esc(child);
+					}
 				}
 			}
+		} else {
+			s += innerHTML;
 		}
 
 		s += `</${name}>`;

--- a/test/vhtml.js
+++ b/test/vhtml.js
@@ -165,4 +165,20 @@ describe('vhtml', () => {
 			'<div class="my-class" for="id"></div>'
 		);
 	});
+
+	it('should support dangerouslySetInnerHTML', () => {
+		expect(
+			<div dangerouslySetInnerHTML={{__html: '<foo>&amp;</foo>'}}></div>
+		).to.equal(
+			'<div><foo>&amp;</foo></div>'
+		);
+	});
+
+	it('should support dangerouslySetInnerHTML (without __html)', () => {
+		expect(
+			<div dangerouslySetInnerHTML>foo</div>
+		).to.equal(
+			'<div></div>'
+		);
+	});
 });


### PR DESCRIPTION
Using the `dangerouslySetInnerHTML` attribute disables automatic escaping of `&<>"'`; see https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml.