### PR TITLE
Support boolean attributes

### DIFF
--- a/src/vhtml.js
+++ b/src/vhtml.js
@@ -28,9 +28,13 @@ export default function h(name, attrs) {
 
 	if (name) {
 		s += '<' + name;
-		if (attrs) for (let i in attrs) {
-			if (attrs[i]!==false && attrs[i]!=null && i !== setInnerHTMLAttr) {
-				s += ` ${DOMAttributeNames[i] ? DOMAttributeNames[i] : esc(i)}="${esc(attrs[i])}"`;
+		if (attrs) {
+			for (let i in attrs) {
+				if (attrs[i] === true && i !== setInnerHTMLAttr) {
+					s += ` ${esc(i)}`;
+				} else if (attrs[i] !== false && attrs[i] != null && i !== setInnerHTMLAttr) {
+					s += ` ${DOMAttributeNames[i] ? DOMAttributeNames[i] : esc(i)}="${esc(attrs[i])}"`;
+				}
 			}
 		}
 		s += '>';

--- a/test/vhtml.js
+++ b/test/vhtml.js
@@ -196,6 +196,11 @@ describe('vhtml', () => {
 		).to.equal(
 			'<div hidden></div>'
 		);
+		expect(
+			<div hidden={false} />
+		).to.equal(
+			'<div></div>'
+		);
 	});
 
 });

--- a/test/vhtml.js
+++ b/test/vhtml.js
@@ -190,4 +190,12 @@ describe('vhtml', () => {
 		);
 	});
 
+	it('should support boolean attributes', () => {
+		expect(
+			<div hidden={true} />
+		).to.equal(
+			'<div hidden></div>'
+		);
+	});
+
 });


### PR DESCRIPTION
I noticed that attributes with a value of (literal) `true` output `attr="true"` rather than just the attribute itself. Boolean attributes don't require a value though, so this PR changes the behavior so that:

```jsx
<div hidden={true} />
```

renders:

```html
<div hidden></div>
```

I added tests for `hidden={true}` and `hidden={false}`. I also did notice in https://github.com/preactjs/preact-render-to-string/issues/4 that there are more complicated rules for boolean attributes in that package, but I'm not sure that this one needs 100% parity. If so, feel free to dismiss this 😁 