### PR TITLE
[FIX] remove `__self` and `__source` from props.

### DIFF
--- a/src/vhtml.js
+++ b/src/vhtml.js
@@ -29,7 +29,8 @@ export default function h(name, attrs) {
 	if (name) {
 		s += '<' + name;
 		if (attrs) for (let i in attrs) {
-			if (attrs[i]!==false && attrs[i]!=null && i !== setInnerHTMLAttr) {
+			// remove `__self` and `__source` from attributes(props).
+			if (!/^__s(elf|ource)$/.test(attrs[i]) && attrs[i]!==false && attrs[i]!=null && i !== setInnerHTMLAttr) {
 				s += ` ${DOMAttributeNames[i] ? DOMAttributeNames[i] : esc(i)}="${esc(attrs[i])}"`;
 			}
 		}

--- a/src/vhtml.js
+++ b/src/vhtml.js
@@ -30,7 +30,7 @@ export default function h(name, attrs) {
 		s += '<' + name;
 		if (attrs) for (let i in attrs) {
 			// remove `__self` and `__source` from attributes(props).
-			if (!/^__s(elf|ource)$/.test(attrs[i]) && attrs[i]!==false && attrs[i]!=null && i !== setInnerHTMLAttr) {
+			if (!/^__s(elf|ource)$/.test(i) && attrs[i]!==false && attrs[i]!=null && i !== setInnerHTMLAttr) {
 				s += ` ${DOMAttributeNames[i] ? DOMAttributeNames[i] : esc(i)}="${esc(attrs[i])}"`;
 			}
 		}


### PR DESCRIPTION
@developit 

Babel like tools adds `__self` and `__source` to attributes(props)

See it on [Sucrase playground](https://sucrase.io/)